### PR TITLE
Adding exception pass in adjust step.

### DIFF
--- a/bitcrush.py
+++ b/bitcrush.py
@@ -101,10 +101,14 @@ class Converter(object):
 
     def adjust(self, b_factor, c_factor):
         """ Adjust brightness/contrast. """
-        img = self.image
-        i = ImageEnhance.Brightness(img).enhance(b_factor)
-        i = ImageEnhance.Contrast(i).enhance(c_factor)
-        self.image = i
+        try:
+            img = self.image
+            i = ImageEnhance.Brightness(img).enhance(b_factor)
+            i = ImageEnhance.Contrast(i).enhance(c_factor)
+            self.image = i
+        except:
+            print("[WARN] unable to enhance Brightness and Contrast, ignoring this step.\n")
+            pass
 
     def _resize(self):
         """ Resize image for previewing and saving """


### PR DESCRIPTION
related issue: https://github.com/asahala/Bitcrush/issues/1

In order to make it working in PNG transparent without Brightness and Contrast adjustments, I added an exception pass in this method. 

I've been working in some retro-game textures mod and I realize that isn't necessary these kind of adjustments in CGA conversion. 

Example:
![BOS2A1C1](https://user-images.githubusercontent.com/537368/133944232-9fd7e174-e7d0-4f22-a73f-0fd5d9bdb936.png)

![BOS2A1C1](https://user-images.githubusercontent.com/537368/133944235-f8211df2-ab94-4074-8a5a-bc0a757a00ea.png)

